### PR TITLE
Add role list function

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "becca_lyria",
   "author": "Nicholas Carrigan",
   "main": "./prod/src/main.js",
-  "version": "7.2.2",
+  "version": "7.2.3",
   "license": "Hippocratic 2.1",
   "private": false,
   "engines": {

--- a/src/commands/server/role.ts
+++ b/src/commands/server/role.ts
@@ -1,9 +1,12 @@
 import CommandInt from "@Interfaces/CommandInt";
+import { MessageEmbed } from "discord.js";
 
 const role: CommandInt = {
   name: "role",
   description: "Adds or removes an assignable role from the user.",
-  parameters: ["`<@role>`: The role to assign."],
+  parameters: [
+    "`<role>`: The name of the role to assign. Optionally use `listall` to get a list of roles.",
+  ],
   run: async (message, config) => {
     try {
       const { author, channel, guild, commandArguments } = message;
@@ -20,6 +23,20 @@ const role: CommandInt = {
         await message.reply(
           "Would you please try the command again, and provide the role you would like to add or remove?"
         );
+        return;
+      }
+
+      // If argument is to list all roles
+      if (targetRole === "listall") {
+        const roleList = new MessageEmbed();
+        roleList.setColor(message.bot.color);
+        roleList.setTitle("Self-Assignable Roles");
+        roleList.setDescription(
+          "These are the roles you can assign yourself: \n" +
+            config.self_roles.map((el) => `<@&${el}>`).join("\n")
+        );
+
+        await channel.send(roleList);
         return;
       }
 


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

Modifies the `role` command to accept `listall` instead of a role. This returns a list of self-assignable roles for that server.

<!--A brief description of what your pull request does.-->

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX

## Scope:

Did you remember to update the `package.json` version number?

- [ ] Major Version Update: X.\_.\_ (for complete code refactors, or large PRs that adjust most of the codebase)
- [ ] Minor Version Update: \_.X.\_ (for the addition of new commands)
- [X] Patch Version Update: \_.\_.X (for bug fixes _in the code_.)
- [ ] No Version Update: \_.\_.\_ (no version update for additions to tests, documentation, or anything that isn't end-user facing.)

## Code Coverage:

Are all the unit tests passing and have you added tests that cover your changes? Run `npm run coverage`

Coverage Checklist:

- [X] All unit tests passing
- [X] Code that my PR modifies has tests.
- [X] PR defines validation steps.

## Documentation:

For _any_ version updates, please verify if the [documentation page](https://www.nhcarrigan.com/Becca-Lyria-documentation) needs an update. If it does, please [create an issue there](https://github.com/nhcarrigan/Becca-Lyria-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [ ] My contribution does NOT require a documentation update.
- [X] My contribution DOES require a documentation update.
