### PR TITLE
fix: remove users field from about command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Once you have all of your changes made and committed, you can push them to your 
 
 > NOTE: By setting the upstream, any subsequent `push` commands can be done with `git push`, and it will be pushed to the same branch.
 
-ow you can open the pull request! You should see a quick option to do so appear at the top of your repository on GitHub. Click the "Pull Request" button to have GitHub automatically set up the pull request.
+Now you can open the pull request! You should see a quick option to do so appear at the top of your repository on GitHub. Click the "Pull Request" button to have GitHub automatically set up the pull request.
 
 First, change the title of the pull request to match your branch name (following the conventions above!). Then, follow the instructions in the preset Pull Request template (make sure to complete any steps listed!). 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "becca_lyria",
-  "version": "10.2.1",
+  "version": "10.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "becca_lyria",
   "author": "Nicholas Carrigan",
   "main": "./prod/src/main.js",
-  "version": "10.2.1",
+  "version": "10.2.2",
   "license": "AGPL-3.0-or-later",
   "private": false,
   "engines": {

--- a/src/commands/bot/about.ts
+++ b/src/commands/bot/about.ts
@@ -24,7 +24,7 @@ const about: CommandInt = {
       const { Becca, channel } = message;
 
       // Get Becca's commands and version.
-      const { color, commands, guilds, users, version } = Becca;
+      const { color, commands, guilds, version } = Becca;
 
       // Create a new empty embed.
       const aboutEmbed = new MessageEmbed();
@@ -46,9 +46,6 @@ const about: CommandInt = {
 
       // Add Becca's servers count.
       aboutEmbed.addField("Servers", guilds.cache.size, true);
-
-      // Add Becca's users count.
-      aboutEmbed.addField("Users", users.cache.size, true);
 
       // Add the available commands length.
       aboutEmbed.addField(


### PR DESCRIPTION
Signed-off-by: galahad42 <amritanand1407@gmail.com>

# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:
Removes `users` field from the embed in `about` command
<!--A brief description of what your pull request does.-->

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #519 

## Scope:

Did you remember to update the `package.json` version number?

- [ ] Major Version Update: X.\_.\_ (for complete code refactors, or large PRs that adjust most of the codebase)
- [ ] Minor Version Update: \_.X.\_ (for the addition of new commands)
- [ ] Patch Version Update: \_.\_.X (for bug fixes _in the code_.)
- [x] No Version Update: \_.\_.\_ (no version update for additions to tests, documentation, or anything that isn't end-user facing.)

## Documentation:

For _any_ version updates, please verify if the [documentation page](https://beccalyria.nhcarrigan.com) needs an update. If it does, please [create an issue there](https://github.com/nhcarrigan/Becca-Lyria-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [x] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
