### PR TITLE
fix:changed the poll duration description

### DIFF
--- a/src/commands/community.ts
+++ b/src/commands/community.ts
@@ -172,7 +172,7 @@ export const community: Command = {
         .addIntegerOption((option) =>
           option
             .setName("duration")
-            .setDescription("The length of time to mute the user.")
+            .setDescription("The length of time for the poll to remain active.")
             .setRequired(true)
         )
         .addStringOption((option) =>


### PR DESCRIPTION
# Pull Request

<!-- Before contributing, please read our contributing guidelines https://becca.nhcarrigan.com/#/contribute -->

## Description

<!-- A brief description of what your pull request does. -->

Changed the poll duration description from  ``` .setDescription("The length of time to mute the user.") ```  to  
```  .setDescription("The length of time for the poll to remain active.") ```

## Related Issue

<!-- Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number. -->

Closes #1888 

## Documentation

For _any_ version updates, please verify if the [documentation page](https://becca.nhcarrigan.com?utm_source=github&utm_medium=pr-template) needs an update. If it does, please [create an issue there](https://github.com/BeccaLyria/discord-documentation/issues/new?assignees=nhcarrigan&labels=%F0%9F%9A%A6+status%3A+awaiting+triage&template=update.md&title=%5BUPDATE%5D) to ensure it is not forgotten.

- [ ] My contribution does NOT require a documentation update.
- [ ] My contribution DOES require a documentation update.
